### PR TITLE
remove pkg-resources==0.0.0 from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,10 @@ parso==0.8.2
 pexpect==4.8.0
 pickleshare==0.7.5
 Pillow==8.2.0
-pkg-resources==0.0.0
+"""
+  <(o )__
+   ( .> /
+"""
 prometheus-client==0.10.1
 prompt-toolkit==3.0.18
 ptyprocess==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,10 +36,6 @@ parso==0.8.2
 pexpect==4.8.0
 pickleshare==0.7.5
 Pillow==8.2.0
-"""
-  <(o )__
-   ( .> /
-"""
 prometheus-client==0.10.1
 prompt-toolkit==3.0.18
 ptyprocess==0.7.0


### PR DESCRIPTION
the dependency is problematic for building docker images for mybinder.org
ERROR: Could not find a version that satisfies the requirement pkg-resources==0.0.0
ERROR: No matching distribution found for pkg-resources==0.0.0
Removing intermediate container 0a4a612a6c6d
The command '/bin/sh -c ${KERNEL_PYTHON_PREFIX}/bin/pip install --no-cache-dir -r "requirements.txt"' returned a non-zero code: 1